### PR TITLE
Make getter configurable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,7 @@ function init() {
 
         var computedStyle: CSSStyleDeclaration = getComputedStyle(a1)
         Object.defineProperty(elementComputedStyle, attr, {
+            configurable: true,
             get() {
                 return parseFloat(computedStyle.paddingBottom)
             }


### PR DESCRIPTION
I was getting the following error when trying to use the library:
> Attempting to change the getter of an unconfigurable property

Did a quick research and found that
> It is not possible to switch between data and accessor property types when the property is non-configurable.

[See reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#Modifying_a_property)

Adding `configurable : true` fixes it.